### PR TITLE
chore: force release version 2.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "release-as": "2.0.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
## Summary
Add `release-as: 2.0.0` to release-please config to force the next release to be v2.0.0.

**Note:** Remove `release-as` line after the 2.0.0 release is created so future versions bump normally.