### PR TITLE
fix: enable glob for Chrome Web Store upload path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,4 @@ jobs:
           client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
           refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
           publish: true
+          glob: true


### PR DESCRIPTION
The chrome-extension-upload action doesn't expand globs by default. Added \ to fix the upload.