### PR TITLE
chore: remove unused square.css from content scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
         "https://www.geocaching.com/geocache/GC*",
         "https://*.geocaching.com/geocache/GC*"
       ],
-      "css": ["square.css", "style.css"],
+      "css": ["style.css"],
       "js": ["init.js", "content_script.js"]
     }
   ],


### PR DESCRIPTION
## Summary
Remove `square.css` from the content_scripts CSS array in manifest.json.

## Why
The iCheck checkbox styling (`square.css`) was incorrectly included in content_scripts but is only used by the popup. The content script doesn't use any iCheck components - it only injects `inject.js` into the page.

## Changes
- Removed `square.css` from `content_scripts.css` array in manifest.json

## Test plan
- [ ] Load extension and visit a geocache page
- [ ] Verify friends logs still display correctly
- [ ] Verify log highlighting still works