### PR TITLE
fix: sync manifest.json version with package.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Geocaching.com Friends Logs",
   "description": "Shows your friends logs at the top of the window, so you don't need to View logbook>friends logs on every cache.",
-  "version": "2.0.0",
+  "version": "2.1.0",
 
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
Add build-time version sync to ensure manifest.json always matches package.json.

## Problem
Release-please's `extra-files` config wasn't updating manifest.json during releases ([known issues](https://github.com/googleapis/release-please/issues/2205)). This caused Chrome Web Store uploads to fail:
- package.json: 2.1.0
- manifest.json: 2.0.0

## Solution
Instead of relying on release-please, sync the version at build time:
- Added `scripts/sync-version.js` - copies version from package.json to manifest.json
- Updated `build` and `build:zip` scripts to run sync-version first
- Removed broken `extra-files` config from release-please-config.json

This way, whenever the release workflow runs `npm run build:zip`, the manifest.json version is automatically synced before creating the zip.

## Test plan
- [x] `npm run build` syncs version and validates
- [ ] Merge to main triggers release-please
- [ ] New release creates zip with correct version
- [ ] Chrome Web Store upload succeeds