### PR TITLE
fix: add build-time version sync for manifest.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "lint:fix": "eslint *.js --fix",
     "format": "prettier --write *.js *.json *.html *.css --ignore-path .prettierignore",
     "format:check": "prettier --check *.js *.json *.html *.css --ignore-path .prettierignore",
-    "build": "node scripts/build.js",
-    "build:zip": "node scripts/zip.js",
+    "sync-version": "node scripts/sync-version.js",
+    "build": "npm run sync-version && node scripts/build.js",
+    "build:zip": "npm run sync-version && node scripts/zip.js",
     "test": "echo \"No tests configured yet\" && exit 0"
   },
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,16 +3,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "release-as": "2.0.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "manifest.json",
-          "jsonpath": "$.version"
-        }
-      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * Syncs version from package.json to manifest.json.
+ * This ensures the Chrome extension version matches the npm package version.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const PACKAGE_PATH = path.join(ROOT_DIR, 'package.json');
+const MANIFEST_PATH = path.join(ROOT_DIR, 'manifest.json');
+
+function syncVersion() {
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_PATH, 'utf8'));
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+
+  if (pkg.version === manifest.version) {
+    console.log(`Version already in sync: ${pkg.version}`);
+    return;
+  }
+
+  console.log(`Syncing version: ${manifest.version} -> ${pkg.version}`);
+  manifest.version = pkg.version;
+
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+  console.log('✓ manifest.json updated');
+}
+
+syncVersion();


### PR DESCRIPTION
## Summary
Add build-time version sync to ensure manifest.json always matches package.json.

## Problem
Release-please's `extra-files` config wasn't updating manifest.json during releases. This caused Chrome Web Store uploads to fail with version mismatch.

## Solution
- Add `scripts/sync-version.js` to copy version from package.json to manifest.json
- Run sync-version automatically before `build` and `build:zip`
- Remove broken `extra-files` config from release-please-config.json

## Test plan
- [x] `npm run build` syncs version and validates
- [ ] Merge to main, then merge release PR #24
- [ ] Chrome Web Store upload succeeds with correct version