### PR TITLE
fix: show personal log when no friends' logs exist

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -50,7 +50,7 @@
           return;
         }
 
-        if (response.pageInfo.rows === 0) {
+        if (response.pageInfo.rows === 0 && typeof loadPersonalAfter === 'undefined') {
           return;
         }
 


### PR DESCRIPTION
## Summary
- Fixes bug where "Show my Log" didn't work when no friends had logged the cache
- Modified early return condition to continue when personal logs are configured to load after friends' logs

## Root Cause
When both settings were enabled, the code would:
1. Set `loadPersonalAfter = 'true'` and fetch friends' logs first
2. If friends' logs returned 0 rows → early return at line 53
3. Never reach line 132-133 where personal logs would be fetched

## Fix
Changed the early return condition from:
```javascript
if (response.pageInfo.rows === 0) {
```
to:
```javascript
if (response.pageInfo.rows === 0 && typeof loadPersonalAfter === 'undefined') {
```

## Test plan
- [ ] Enable both "Show Friends Logs" and "Show my Log" in popup
- [ ] Navigate to a cache you've found but none of your friends have logged
- [ ] Verify your log appears at the top with "My Log" header
- [ ] Test cache with both friends' logs and your log → both should appear
- [ ] Test cache with only friends' logs (you haven't found) → friends' logs appear

Fixes #31