### PR TITLE
docs: add Brave browser support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ A browser extension that displays your friends' geocaching logs at the top of ev
 
 ### Manual Installation
 
-#### Chrome / Edge / Opera / Brave
+#### Chrome (incl. Brave) / Edge / Opera
 1. Download the latest release for your browser from the [Releases page](https://github.com/rfsbraz/Geocaching.com-Friends-Logs/releases)
+   - For Brave, download the Chrome/Chromium release zip.
 2. Unzip the file
 3. Open your browser's extension page:
    - Chrome: `chrome://extensions`


### PR DESCRIPTION
## Summary
- Added Brave to the browser extension stores section (pointing to Chrome Web Store since Brave supports Chrome extensions natively)
- Added Brave to manual installation and development sections with `brave://extensions` URL

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `brave://extensions` is the correct URL for Brave's extension page