### PR TITLE
fix: extension stops working after first use on Brave/Linux

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -15,7 +15,7 @@ function injectScript(file, node, showMyLogs, showFriendsLogs, limit) {
 
   const s = document.createElement('script');
   s.setAttribute('type', 'text/javascript');
-  s.setAttribute('src', file);
+  s.setAttribute('src', file + '?t=' + Date.now());
   s.setAttribute('id', 'inject');
   s.setAttribute('showFriendsLogs', String(showFriendsLogs));
   s.setAttribute('showMyLogs', String(showMyLogs));
@@ -23,13 +23,43 @@ function injectScript(file, node, showMyLogs, showFriendsLogs, limit) {
   th.appendChild(s);
 }
 
-chrome.storage.local.get(DEFAULT_VALUES, function (items) {
-  const showMyLogs = items.showMyLogs;
-  const showFriendsLogs = items.showFriendsLogs;
-  const limit = items.limit;
+function doInject() {
+  // Only inject if not already injected
+  if (document.getElementById('inject')) {
+    return;
+  }
 
-  // Only inject if at least one option is enabled and not already injected
-  if ((showMyLogs || showFriendsLogs) && !document.getElementById('inject')) {
-    injectScript(chrome.runtime.getURL('inject.js'), 'body', showMyLogs, showFriendsLogs, limit);
+  chrome.storage.local.get(DEFAULT_VALUES, function (items) {
+    if (chrome.runtime.lastError) {
+      console.warn('[Friends Logs] Storage read failed:', chrome.runtime.lastError.message);
+      // Fall back to defaults so injection still happens
+      items = DEFAULT_VALUES;
+    }
+
+    const showMyLogs = items.showMyLogs;
+    const showFriendsLogs = items.showFriendsLogs;
+    const limit = items.limit;
+
+    // Only inject if at least one option is enabled and not already injected
+    if ((showMyLogs || showFriendsLogs) && !document.getElementById('inject')) {
+      console.log('[Friends Logs] Injecting script');
+      injectScript(chrome.runtime.getURL('inject.js'), 'body', showMyLogs, showFriendsLogs, limit);
+    }
+  });
+}
+
+console.log('[Friends Logs] Content script loaded');
+doInject();
+
+// Handle pages restored from bfcache (back/forward cache)
+window.addEventListener('pageshow', function (event) {
+  if (event.persisted) {
+    console.log('[Friends Logs] Page restored from bfcache, re-injecting');
+    // Remove old inject element so the guard check passes
+    const old = document.getElementById('inject');
+    if (old) {
+      old.remove();
+    }
+    doInject();
   }
 });

--- a/inject.js
+++ b/inject.js
@@ -6,6 +6,8 @@
 (function () {
   'use strict';
 
+  console.log('[Friends Logs] Inject script executing');
+
   /**
    * Load logs from the geocaching.com logbook API.
    * @param {number} pageIdx - Page index (0-based)
@@ -149,6 +151,26 @@
   const showFriendsLogs = injectElement.getAttribute('showFriendsLogs');
   const limit = injectElement.getAttribute('limit');
 
-  // Start loading logs
-  loadLogbookPage(0, showMyLogs, showFriendsLogs, limit);
+  /**
+   * Wait for page globals (userToken, jQuery) to be available before loading logs.
+   * Retries up to 10 times at 500ms intervals (5s total).
+   */
+  function waitForGlobalsAndLoad(retries) {
+    if (typeof userToken !== 'undefined' && typeof $ !== 'undefined') {
+      loadLogbookPage(0, showMyLogs, showFriendsLogs, limit);
+      return;
+    }
+
+    if (retries <= 0) {
+      console.error('[Friends Logs] Page globals not available after retries');
+      return;
+    }
+
+    console.log('[Friends Logs] Waiting for page globals (' + retries + ' retries left)');
+    setTimeout(function () {
+      waitForGlobalsAndLoad(retries - 1);
+    }, 500);
+  }
+
+  waitForGlobalsAndLoad(10);
 })();


### PR DESCRIPTION
## Summary

- Cache-bust `inject.js` URL with a timestamp query parameter to prevent stale cached copies on subsequent navigations
- Handle bfcache (back/forward cache) page restoration by re-injecting when `pageshow` fires with `event.persisted`
- Add retry logic for page globals (`userToken`, jQuery) that may not be immediately available
- Add `chrome.storage.local` error handling with fallback to defaults
- Add diagnostic `console.log` breadcrumbs for easier debugging

## Test plan

- [x] Load extension in Brave on Linux, visit a geocache page — logs appear
- [x] Navigate to a second geocache page — logs still appear (the reported bug scenario)
- [x] Use back/forward buttons — logs still appear (bfcache scenario)
- [x] Check DevTools console for `[Friends Logs]` breadcrumb chain on each load
- [x] Verify Chrome, Firefox, Edge, Opera are unaffected

Closes #45